### PR TITLE
Adds "Insert at Position" and fixes issues with Creation tests

### DIFF
--- a/TechTest/IsometrixTechTest/DataStructures/GenericLinkedList.cs
+++ b/TechTest/IsometrixTechTest/DataStructures/GenericLinkedList.cs
@@ -45,6 +45,27 @@ public class GenericLinkedList<T> : IGenericLinkedList<T>
         return newNode;
     }
 
+    public INode<T> Insert(int position, T newNodeValue)
+    {
+        var newNode = new Node<T>
+        {
+            Value = newNodeValue,
+        };
+
+        if (position == 0)
+        {
+            newNode.NextNode = GetHeadNode();
+            HeadNode = newNode;
+
+            return newNode;
+        }
+
+        var nodeAtPosition = GetNodeAtPosition(position - 1);
+        nodeAtPosition.NextNode = newNode;
+
+        return newNode;
+    }
+
     // The spec said "Insert" should just insert at any position, but I thought realistically an Insert with Append
     // behaviour might also be nice
     public INode<T> Insert(T newNodeValue)
@@ -54,7 +75,7 @@ public class GenericLinkedList<T> : IGenericLinkedList<T>
         {
             last = last.NextNode;
         }
-        
+
         var newNode = new Node<T> { Value = newNodeValue };
         last.NextNode = newNode;
 
@@ -89,7 +110,7 @@ public class GenericLinkedList<T> : IGenericLinkedList<T>
     {
         var currentNode = GetHeadNode();
         var response = "";
-        
+
         // We have nothing in this list at all
         if (currentNode.Value == null && currentNode.NextNode == null)
         {
@@ -109,8 +130,25 @@ public class GenericLinkedList<T> : IGenericLinkedList<T>
         response += currentNode.Value;
 
         return response;
-        
+
         // (Alternatively you could loop values, add them to a list and then string.Join the list, but you iterate
         // twice which feels wasteful)
+    }
+
+    private INode<T> GetNodeAtPosition(int position)
+    {
+        var node = GetHeadNode();
+
+        for (var i = 0; i < position; i++)
+        {
+            node = node?.NextNode;
+        }
+
+        if (node == null)
+        {
+            throw new NodeNotFoundInListException();
+        }
+
+        return node;
     }
 }

--- a/TechTest/IsometrixTechTest/DataStructures/IGenericLinkedList.cs
+++ b/TechTest/IsometrixTechTest/DataStructures/IGenericLinkedList.cs
@@ -8,6 +8,8 @@ public interface IGenericLinkedList<T>
 
     // I opted to return the inserted node once created - some languages have a void response here
     public INode<T> Insert(INode<T> nodeToInsertAfter, T newNodeValue);
+    
+    public INode<T> Insert(int position, T newNodeValue);
 
     // Will append to the last node
     public INode<T> Insert(T newNodeValue);

--- a/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/CreateTests.cs
+++ b/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/CreateTests.cs
@@ -16,10 +16,10 @@ public class CreateTests : LinkedListTestBase
         var boolList = GenericLinkedList<bool>.Create();
         var objectList = GenericLinkedList<TestModel>.Create();
 
-        intList.GetHeadNode().Should().BeNull();
-        stringList.GetHeadNode().Should().BeNull();
-        boolList.GetHeadNode().Should().BeNull();
-        objectList.GetHeadNode().Should().BeNull();
+        intList.GetHeadNode().Value.Should().Be(0);
+        stringList.GetHeadNode().Value.Should().BeNull();
+        boolList.GetHeadNode().Value.Should().Be(false);
+        objectList.GetHeadNode().Value.Should().BeNull();
     }
 
     [Test]
@@ -30,9 +30,9 @@ public class CreateTests : LinkedListTestBase
         const bool testBoolData = true;
         const string testObjectData = "Test Model Data";
 
-        var intList = GenericLinkedList<int>.Create(10);
-        var stringList = GenericLinkedList<string>.Create("hello");
-        var boolList = GenericLinkedList<bool>.Create(true);
+        var intList = GenericLinkedList<int>.Create(testIntData);
+        var stringList = GenericLinkedList<string>.Create(testStringData);
+        var boolList = GenericLinkedList<bool>.Create(testBoolData);
         var objectList = GenericLinkedList<TestModel>.Create(
             new TestModel
             {
@@ -44,6 +44,6 @@ public class CreateTests : LinkedListTestBase
         intList.GetHeadNode().Value.Should().Be(testIntData);
         stringList.GetHeadNode().Value.Should().Be(testStringData);
         boolList.GetHeadNode().Value.Should().Be(testBoolData);
-        objectList.GetHeadNode().Value.Data.Should().Be(testObjectData);
+        objectList.GetHeadNode().Value?.Data.Should().Be(testObjectData);
     }
 }

--- a/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/DeleteTests.cs
+++ b/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/DeleteTests.cs
@@ -67,6 +67,18 @@ public class DeleteTests : LinkedListTestBase
     }
 
     [Test]
+    public void Delete_LastNode_CorrectlyRemovesLastNode()
+    {
+        var list = CreateGenericLinkedList(100, 200, 300);
+
+        var node = list.GetHeadNode().NextNode?.NextNode;
+
+        node.Should().NotBeNull();
+
+        list.Delete(node);
+    }
+
+    [Test]
     public void Delete_OutOfBoundsPosition_ThrowsException()
     {
         var list = CreateGenericLinkedList(100, 200, 300);

--- a/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/InsertTests.cs
+++ b/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/InsertTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using DataStructures;
+using DataStructures.Exceptions;
 using FluentAssertions;
 
 namespace UnitTests.LinkedListTests;
@@ -17,7 +18,7 @@ public class InsertTests : LinkedListTestBase
 
         second.Value.Should().Be(200);
         second.NextNode.Should().Be(third);
-        
+
         var headNode = intList.GetHeadNode();
         headNode.Value.Should().Be(100);
         headNode.NextNode?.Value.Should().Be(200);
@@ -25,7 +26,7 @@ public class InsertTests : LinkedListTestBase
     }
 
     [Test]
-    public void Insert_SupplyPositionAndNewValue_AppendsAfterGivenNode()
+    public void Insert_SupplyNodeAndNewValue_InsertsAfterGivenNode()
     {
         var list = CreateGenericLinkedList(100, 200, 300);
 
@@ -44,5 +45,51 @@ public class InsertTests : LinkedListTestBase
         list.GetHeadNode().NextNode?.Value.Should().Be(200);
         list.GetHeadNode().NextNode?.NextNode?.Value.Should().Be(900);
         list.GetHeadNode().NextNode?.NextNode?.NextNode?.Value.Should().Be(300);
+    }
+
+    [Test]
+    public void Insert_SupplyFinalNodeAndNewValue_AppendsToList()
+    {
+        var list = CreateGenericLinkedList(100, 200, 300);
+
+        var finalNode = list.GetHeadNode().NextNode?.NextNode;
+        finalNode.Should().NotBeNull();
+
+        list.Insert(finalNode, 400);
+
+        list.GetHeadNode().NextNode?.NextNode?.NextNode?.Value.Should().Be(400);
+    }
+
+    [Test]
+    public void Insert_SupplyPositionAndNewValue_InsertsAtGivenPosition()
+    {
+        var list = CreateGenericLinkedList(100, 200, 300);
+
+        var newNode = list.Insert(0, 10);
+
+        list.GetHeadNode().Should().Be(newNode);
+    }
+
+    [Test]
+    public void Insert_SupplyPositionJustAfterLastValue_AppendsToList()
+    {
+        var list = CreateGenericLinkedList(100, 200, 300);
+
+        var newNode = list.Insert(3, 400);
+
+        list.GetHeadNode()
+            .NextNode?
+            .NextNode?
+            .NextNode.Should().Be(newNode);
+    }
+
+    [Test]
+    public void Insert_SupplyInvalidPosition_ThrowsException()
+    {
+        var list = CreateGenericLinkedList(100, 200, 300);
+
+        Action action = () => list.Insert(30, 400);
+
+        action.Should().Throw<NodeNotFoundInListException>();
     }
 }

--- a/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/PrintListTests.cs
+++ b/TechTest/IsometrixTechTest/UnitTests/LinkedListTests/PrintListTests.cs
@@ -9,7 +9,6 @@ namespace UnitTests.LinkedListTests;
 public class PrintListTests : LinkedListTestBase
 {
     [Test]
-    // Decided to keep default value and not null here, as I'm a fan of this approach (null references are a pain!)
     public void PrintList_EmptyList_ReturnsDefaultValueAsString()
     {
         var intList = GenericLinkedList<int>.Create();
@@ -21,6 +20,14 @@ public class PrintListTests : LinkedListTestBase
         stringList.PrintList().Should().Be(string.Empty);
         boolList.PrintList().Should().Be("False");
         objectList.PrintList().Should().Be(string.Empty);
+    }
+
+    [Test]
+    public void PrintList_WithSingleNode_ReturnsNodeValue()
+    {
+        var intList = CreateGenericLinkedList(100);
+
+        intList.PrintList().Should().Be("100");
     }
 
     [Test]


### PR DESCRIPTION
I have added the ability to add a node at a given numerical position in the LinkedList along with tests to support this.

I also performed a test run and discovered broken `Create()` tests which somehow I've entirely missed (feeling pretty stupid!). This PR fixes those and now compares the values within the head node to the default expected value.

In addition I have added a test for creation with nullable types, for when the default value is insufficient, as this struck me as another flaw.